### PR TITLE
add support for enumerated field types

### DIFF
--- a/gqlrequests/query.py
+++ b/gqlrequests/query.py
@@ -4,6 +4,7 @@ import dataclasses
 import typing
 from keyword import iskeyword
 from typing import List, Optional
+from enum import Enum
 
 from typing_inspect import is_generic_type  # type: ignore
 
@@ -66,6 +67,9 @@ class Query:
                 "bool",
             ]
 
+        def is_enumerated(f):
+            return issubclass(f, Enum)
+
         # First add the fields that are not QueryMethods (this will be added last)
         for field, field_type in resolved_field_types.items():
 
@@ -97,7 +101,7 @@ class Query:
             # If the field is a list of primtives, or just a primtive, only add the field name
             elif is_primitive(field_type) or (
                 is_list(field_type) and is_primitive(field_type.__args__[0])
-            ):
+            ) or is_enumerated(field_type):
                 field_string = field
 
             # If the field is not a primitive type or a dataclass (or any of those two in a list), raise an error

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     long_description_content_type="text/markdown",
     packages=["gqlrequests"],
     package_data={"gqlrequests": ["py.typed"]},
-    install_requires=["typing_inspect~=0.8.0"],
+    install_requires=["typing_inspect~=0.8.0", "pytest~=7.2.1"],
     license="MIT",
     version=__version__,
     description="A Python library for making GraphQL requests easier!",

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from enum import Enum
 from typing import List
 
 import pytest
@@ -43,6 +44,17 @@ class DatatypeWithKeywordAsProperty:
     type: str  # This is okay, because type is a reserved *function*, not keyword
     from_: str
     as_: int
+
+
+class SomeEnumClass(Enum):
+    ONE = 1
+    TWO = 2
+    THREE = 3
+
+
+@dataclass
+class ClassWithEnumeratedFieldType:
+    enumerated: SomeEnumClass
 
 
 def test_primitive_types():
@@ -125,13 +137,15 @@ def test_listed_types():
 }
 """[1:-1]
 
+
 def test_invalid_type_throws_value_error():
     with pytest.raises(ValueError) as e:
         str(Query(InvalidType))
-    
+
     # Ensure the error message contains the name of the invalid property 
     # and the name of the class - this is to help the user debug the issue
     assert "invalidProperty" in str(e.value) and "InvalidType" in str(e.value)
+
 
 def test_keyword_as_property_gets_stripped_for_underscores():
     assert str(Query(DatatypeWithKeywordAsProperty)) == """
@@ -141,6 +155,7 @@ def test_keyword_as_property_gets_stripped_for_underscores():
     as
 }
 """[1:-1]
+
 
 def test_start_indent():
     # Note that the first bracket is not indented. This is intentional because
@@ -154,4 +169,12 @@ def test_start_indent():
     name
     company
   }
+"""[1:-1]
+
+
+def test_enumerated_field_type():
+    assert str(Query(ClassWithEnumeratedFieldType)) == """
+{
+    enumerated
+}
 """[1:-1]


### PR DESCRIPTION
I have included your lib for my project at work, had to do few workarounds but most of the library worked for me.

 It would be nice  if your library could handle enumerated field types as well. The changes and tests are included in my PR , I put the check for enumerated after checking for list type in `query.py` for the reason I don't know yet how to test for List[Enum] and I am not sure support for this type of field  is ever needed. Feel free to change suggest in my PR.