### PR TITLE
Generate function queries with primitive arguments and enum values

### DIFF
--- a/gqlrequests/builder.py
+++ b/gqlrequests/builder.py
@@ -161,9 +161,10 @@ class QueryBuilder(abc.ABC):
         return self
 
     def _generate_function(self) -> str:
-        func_args = ", ".join(
-            f"{key}: {value}" for key, value in self._func_args.items()
-        )
+        if self._func_args:
+            func_args = ", ".join(
+                f"{key}: {value}" for key, value in self._func_args.items()
+            )
 
         # Reset temporarily so that the next build call builds the rest of the query
         self._build_function = False

--- a/tests/test_function_calls.py
+++ b/tests/test_function_calls.py
@@ -9,7 +9,6 @@ class EveryType(gqlrequests.QueryBuilder):
     name: str
     company: bool
 
-@pytest.mark.skip(reason="Not implemented yet")
 def test_method_with_no_args():
     correct_string = """
 methodName() {
@@ -19,11 +18,10 @@ methodName() {
     name
     company
 }
-"""
+"""[1:]
     every_type = EveryType(func_name="methodName")
     assert every_type().build() == correct_string
 
-@pytest.mark.skip(reason="Not implemented yet")
 def test_method_with_int_args():
     correct_string = """
 methodName(test: 5) {
@@ -33,7 +31,7 @@ methodName(test: 5) {
     name
     company
 }
-"""
+"""[1:]
     every_type = EveryType(func_name="methodName")
     assert every_type(test=5).build() == correct_string
 
@@ -47,8 +45,8 @@ specialName(test: 5) {
     name
     company
 }
-"""
-    specialName = EveryType()
+"""[1:]
+    specialName = EveryType(func_name="specialName")
     assert specialName(test=5).build() == correct_string
 
 @pytest.mark.skip(reason="Not implemented yet")


### PR DESCRIPTION
TODO: Add non-primitive argument support

The name of the function and the name of the arguments of the function are not restricted or type-checked against a schema in any way. perhaps TODO: add this check?