### PR TITLE
Add strip_underscores argument to build method to facilitate keyword field name

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,14 +154,16 @@ asyncio.run(main())
 ## Edge cases
 
 Some attributes are reserved keywords in Python, such as `from`, `is` and `not`. These cannot be referenced to
-by property like this: `some_query_result.from`. This can be circumvented by using the `StrippedUnderscoreQueryBuilder` like such;
+by property like this: `some_query_result.from`. This can be circumvented by adding leading or trailing underscores,
+then passing the `strip_underscores` argument to the build method.
+
 ```py
-class Time(gqlrequests.StrippedUnderscoreQueryBuilder):
+class Time(gqlrequests.QueryBuilder):
     _from: int
     _to: int
     value: float
 
-print(Time().build())
+print(Time().build(strip_underscores=True))
 # {
 #     from
 #     to

--- a/gqlrequests/builder.py
+++ b/gqlrequests/builder.py
@@ -88,11 +88,14 @@ class QueryBuilder(metaclass=QueryBuilderMeta):
     def get(self, name):
         return getattr(self._query_build_data, name)
 
-    def build(self, indent_size: int = 4, start_indents: int = 0) -> str:
+    def build(self, indent_size: int = 4, start_indents: int = 0, strip_undersores: bool = False) -> str:
         """Generates a GraphQL query string based on the fields set in the
         builder."""
         if not (fields_to_build := self.get("fields_to_build")):
             raise ValueError("No fields were selected for the query builder. Cannot build an empty query.")
+        
+        if strip_undersores:
+            fields_to_build = { key.strip("_"): value for key, value in fields_to_build.items() }
 
         if self.get("build_function"):
             if not (func_name := self.get("func_name")):

--- a/gqlrequests/builder.py
+++ b/gqlrequests/builder.py
@@ -37,9 +37,7 @@ class QueryBuilder(metaclass=QueryBuilderMeta):
     """An abstract class used to build GraphQL queries.
 
     This class should be inherited by a class with type hints and only
-    supports single-leveled inheritance. This version of the QueryBuilder
-    does not support reserved keywords as field names. To use reserved
-    keywords, check the `StrippedUnderscoresQueryBuilder` class.
+    supports single-leveled inheritance.
 
     Example usage:
 

--- a/tests/test_building_options.py
+++ b/tests/test_building_options.py
@@ -145,7 +145,6 @@ class DatatypeWithKeywordAsProperty(gqlrequests.QueryBuilder):
     as_: int
 
 
-@pytest.mark.skip(reason="Not implemented yet")
 def test_keywords_as_field_name_gets_stripped_for_underscores():
     correct_string = """
 {
@@ -153,5 +152,5 @@ def test_keywords_as_field_name_gets_stripped_for_underscores():
     from
     as
 }
-"""
-    assert DatatypeWithKeywordAsProperty().build() == correct_string
+"""[1:]
+    assert DatatypeWithKeywordAsProperty().build(strip_undersores=True) == correct_string


### PR DESCRIPTION
This is a redo of #8 which was accidently rebase merged into main... 